### PR TITLE
Add an extension to bring SFSymbols to the SwiftUI Label

### DIFF
--- a/Sources/SFSymbols/Label+SFSymbol.swift
+++ b/Sources/SFSymbols/Label+SFSymbol.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@available(iOS 14.0, *)
 public extension Label {
   init(_ titleKey: LocalizedStringKey,
        symbol: SFSymbol) where Title == Text, Icon == Image {

--- a/Sources/SFSymbols/Label+SFSymbol.swift
+++ b/Sources/SFSymbols/Label+SFSymbol.swift
@@ -2,23 +2,21 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 public extension Label {
-  init(_ titleKey: LocalizedStringKey,
-       symbol: SFSymbol) where Title == Text, Icon == Image {
-    switch symbol {
-    case .custom(let name):
-      self = Label(titleKey, image: name)
-    default:
-      self = Label(titleKey, systemImage: symbol.name)
+    init(_ titleKey: LocalizedStringKey, symbol: SFSymbol) where Title == Text, Icon == Image {
+        switch symbol {
+        case .custom(let name):
+            self = Label(titleKey, image: name)
+        default:
+            self = Label(titleKey, systemImage: symbol.name)
+        }
     }
-  }
-
-  init<S>(_ title: S,
-          symbol: SFSymbol) where S: StringProtocol, Title == Text, Icon == Image {
-    switch symbol {
-    case .custom(let name):
-      self = Label(title, image: name)
-    default:
-      self = Label(title, systemImage: symbol.name)
+    
+    init<S>(_ title: S, symbol: SFSymbol) where S: StringProtocol, Title == Text, Icon == Image {
+        switch symbol {
+        case .custom(let name):
+            self = Label(title, image: name)
+        default:
+            self = Label(title, systemImage: symbol.name)
+        }
     }
-  }
 }

--- a/Sources/SFSymbols/Label+SFSymbol.swift
+++ b/Sources/SFSymbols/Label+SFSymbol.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+public extension Label {
+  init(_ titleKey: LocalizedStringKey,
+       symbol: SFSymbol) where Title == Text, Icon == Image {
+    switch symbol {
+    case .custom(let name):
+      self = Label(titleKey, image: name)
+    default:
+      self = Label(titleKey, systemImage: symbol.name)
+    }
+  }
+
+  init<S>(_ title: S,
+          symbol: SFSymbol) where S: StringProtocol, Title == Text, Icon == Image {
+    switch symbol {
+    case .custom(let name):
+      self = Label(title, image: name)
+    default:
+      self = Label(title, systemImage: symbol.name)
+    }
+  }
+}


### PR DESCRIPTION
Add an extension to bring SFSymbols to the SwiftUI Label.

Please change code formatting to your liking. I will not be offended.